### PR TITLE
fix: keep SSR DynamoDB PITR disabled for compatibility

### DIFF
--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -14,8 +14,9 @@ module "dynamodb" {
     { name = "PK", type = "S" },
     { name = "SK", type = "S" }
   ]
-  enable_dr = var.enable_dr
-  tags      = local.common_tags
+  enable_pitr = false
+  enable_dr   = var.enable_dr
+  tags        = local.common_tags
 }
 
 resource "aws_dynamodb_table_item" "counter" {


### PR DESCRIPTION
## Summary
- set `enable_pitr = false` in SSR's shared DynamoDB module call
- preserves prior behavior and avoids requiring new IAM permission in existing Terraform Cloud role

## Why
Canary apply on `pomo-ssr` failed because shared module defaults enabled PITR, which required `dynamodb:UpdateContinuousBackups` not currently granted to the run role.

## Validation
- terraform fmt -check -recursive
- make validate
- make test (7 passed)